### PR TITLE
refactor: migration to node. now can be run fron node or deno

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,12 @@ jobs:
       - run: npm ci
       - run: npm test
 
-      - name: Publish package
+      - name: Publish to npm
+        if: startsWith(github.ref, 'refs/tags/v')
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to JSR
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: npx jsr publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
       - run: npm test

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ local:
 compile:
 	deno compile --output=dist/tepi -A src/cli.ts
 
-install-x:
-	npm install -g @garn/tepi
+install:
+	npm install -g @garndev/tepi
 
 udd:
 	npx npm-check-updates -u && npm test
@@ -25,7 +25,7 @@ version:
 	deno run --allow-all jsr:@krlwlfrt/version
 
 version-get:
-	@$(MAKE) --silent version | jq '.["@garn/tepi"]' | sed 's/"//g'
+	@$(MAKE) --silent version | jq '.["@garndev/tepi"]' | sed 's/"//g'
 
 readme:
 	cat docs/started.md > README.md

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test-debug test-docker local compile install-x udd dnt version version-get readme readme-copy release publish-image vhs
+.PHONY: test-debug test-docker local compile install-x udd dnt version version-get readme readme-copy release publish-image vhs publish publish-npm publish-jsr publish-deno
 
 test-debug:
 	NO_LOG=1 npx vitest run -t 'code 0'
@@ -55,3 +55,17 @@ publish-image:
 
 vhs:
 	cd vhs && vhs < demo.tape && git add ./demo.gif && git commit -m vhs
+
+publish-npm:
+	npm publish --access public
+
+publish-jsr:
+	npx jsr publish
+
+publish-deno:
+	@VERSION=$$(node -p "require('./package.json').version"); \
+	echo "Tagging v$$VERSION for deno.land/x..."; \
+	git tag v$$VERSION 2>/dev/null || echo "Tag v$$VERSION already exists"; \
+	git push origin v$$VERSION
+
+publish: publish-npm publish-jsr publish-deno

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Test your HTTP APIs with standard http syntax
 ### From npm
 
 ```bash
-npm install -g @garn/tepi
+npm install -g @garndev/tepi
 ```
 
 ### From JSR
@@ -66,7 +66,7 @@ deno install --global -A -n tepi https://deno.land/x/tepi/mod.ts
 ### Run without installing (npx)
 
 ```bash
-npx @garn/tepi [OPTIONS] [FILES|GLOBS...]
+npx @garndev/tepi [OPTIONS] [FILES|GLOBS...]
 ```
 
 ### Permissions (Deno only):

--- a/README.md
+++ b/README.md
@@ -45,18 +45,31 @@ Test your HTTP APIs with standard http syntax
 
 ## Install:
 
+### From npm
 
 ```bash
-deno install --global --reload  --allow-read --allow-env --allow-net --allow-run -f -n tepi https://tepi.deno.dev/src/cli.ts
+npm install -g @garn/tepi
 ```
 
-Or run remotely with:
+### From JSR
 
 ```bash
-deno run --allow-read --allow-env --allow-net --allow-run https://tepi.deno.dev/src/cli.ts
+npx jsr add -g @garn/tepi
 ```
 
-### Permissions:
+### From deno.land/x
+
+```bash
+deno install --global -A -n tepi https://deno.land/x/tepi/mod.ts
+```
+
+### Run without installing (npx)
+
+```bash
+npx @garn/tepi [OPTIONS] [FILES|GLOBS...]
+```
+
+### Permissions (Deno only):
 
 * `--allow-read`  Needed to read files from the file system.
 * `--allow-net`   Needed to make HTTP requests.

--- a/README.md
+++ b/README.md
@@ -51,16 +51,11 @@ Test your HTTP APIs with standard http syntax
 npm install -g @garndev/tepi
 ```
 
-### From JSR
+
+### In deno
 
 ```bash
-npx jsr add -g @garn/tepi
-```
-
-### From deno.land/x
-
-```bash
-deno install --global -A -n tepi https://deno.land/x/tepi/mod.ts
+deno install --global -A -n tepi jsr:@garn/tepi
 ```
 
 ### Run without installing (npx)

--- a/bin/tepi.mjs
+++ b/bin/tepi.mjs
@@ -1,6 +1,3 @@
-#!/usr/bin/env node
-import { register } from "node:module";
-import { pathToFileURL } from "node:url";
-register("tsx/esm", pathToFileURL("./"));
-const { cli } = await import("../src/cli.ts");
+#!/usr/bin/env -S node --import tsx/esm
+import { cli } from "../src/cli.ts";
 await cli();

--- a/bin/tepi.mjs
+++ b/bin/tepi.mjs
@@ -2,4 +2,5 @@
 import { register } from "node:module";
 import { pathToFileURL } from "node:url";
 register("tsx/esm", pathToFileURL("./"));
-await import("../src/cli.ts");
+const { cli } = await import("../src/cli.ts");
+await cli();

--- a/deno.json
+++ b/deno.json
@@ -4,6 +4,7 @@
   "exports": {
     ".": "./mod.ts"
   },
+  "license": "MIT",
   "tasks": {
     "start": "deno run -A mod.ts"
   }

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,11 @@
+{
+  "name": "@garn/tepi",
+  "version": "2.0.0",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "tasks": {
+    "start": "deno run -A mod.ts",
+    "test": "deno test -A"
+  }
+}

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@garn/tepi",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "exports": {
     ".": "./mod.ts"
   },

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@garn/tepi",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "exports": {
     ".": "./mod.ts"
   },

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@garn/tepi",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "exports": {
     ".": "./mod.ts"
   },

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@garn/tepi",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "exports": {
     ".": "./mod.ts"
   },

--- a/deno.json
+++ b/deno.json
@@ -1,11 +1,10 @@
 {
   "name": "@garn/tepi",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "exports": {
     ".": "./mod.ts"
   },
   "tasks": {
-    "start": "deno run -A mod.ts",
-    "test": "deno test -A"
+    "start": "deno run -A mod.ts"
   }
 }

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,7 @@
 {
   "name": "@garn/tepi",
   "version": "2.0.1",
+  "license": "MIT",
   "exports": {
     ".": "./mod.ts"
   }

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@garn/tepi",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "exports": {
     ".": "./mod.ts"
   }

--- a/jsr.json
+++ b/jsr.json
@@ -1,0 +1,7 @@
+{
+  "name": "@garn/tepi",
+  "version": "2.0.0",
+  "exports": {
+    ".": "./mod.ts"
+  }
+}

--- a/jsr.json
+++ b/jsr.json
@@ -1,8 +1,0 @@
-{
-  "name": "@garn/tepi",
-  "version": "2.0.1",
-  "license": "MIT",
-  "exports": {
-    ".": "./mod.ts"
-  }
-}

--- a/mod.ts
+++ b/mod.ts
@@ -1,7 +1,9 @@
 import { cli } from "./src/cli.ts";
 import { fileURLToPath } from "node:url";
 
-const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+const isMain = import.meta.url.startsWith("file:")
+  ? process.argv[1] === fileURLToPath(import.meta.url)
+  : (import.meta as { main?: boolean }).main ?? false;
 if (isMain) {
   await cli();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,26 @@
 {
-  "name": "@garn/tepi",
-  "version": "1.2.0",
+  "name": "@garndev/tepi",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@garn/tepi",
-      "version": "1.2.0",
+      "name": "@garndev/tepi",
+      "version": "2.0.1",
+      "bundleDependencies": [
+        "@std/assert",
+        "@std/async",
+        "@std/cli",
+        "@std/dotenv",
+        "@std/fmt",
+        "@std/front-matter",
+        "@std/fs",
+        "@std/media-types",
+        "@std/path",
+        "@std/testing",
+        "@wilcosp/ms-relative"
+      ],
+      "license": "MIT",
       "dependencies": {
         "@std/assert": "npm:@jsr/std__assert@^1.0.19",
         "@std/async": "npm:@jsr/std__async@^1.2.0",
@@ -518,6 +532,7 @@
       "version": "1.0.19",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__assert/1.0.19.tgz",
       "integrity": "sha512-pEj6RPkGbqlgRmyKwATp4cUs6+ijxtdrv3bq8v1d2I2CEcMEyPaO8cVKro61wGRDH4cNg8Zx6haztvK/9m7gkA==",
+      "inBundle": true,
       "dependencies": {
         "@jsr/std__internal": "^1.0.12"
       }
@@ -525,17 +540,20 @@
     "node_modules/@jsr/std__async": {
       "version": "1.2.0",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__async/1.2.0.tgz",
-      "integrity": "sha512-/vlTKrVwDp9iBCi1BUlz4ghyvHNkzGHdvhdHTdPKGJoklBcwnRjm4yC0n+oB97LtRRFpruWmBobABZHD/t/SkQ=="
+      "integrity": "sha512-/vlTKrVwDp9iBCi1BUlz4ghyvHNkzGHdvhdHTdPKGJoklBcwnRjm4yC0n+oB97LtRRFpruWmBobABZHD/t/SkQ==",
+      "inBundle": true
     },
     "node_modules/@jsr/std__collections": {
       "version": "1.1.6",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__collections/1.1.6.tgz",
-      "integrity": "sha512-hmuIU7r/xepXLXIBiK9gmq1BnSalyySnfdJ1mqvT39hU2g4Pz0DJDx6z1CMWVGbUQhpxBHuVQH9diqwMoN6/pw=="
+      "integrity": "sha512-hmuIU7r/xepXLXIBiK9gmq1BnSalyySnfdJ1mqvT39hU2g4Pz0DJDx6z1CMWVGbUQhpxBHuVQH9diqwMoN6/pw==",
+      "inBundle": true
     },
     "node_modules/@jsr/std__data-structures": {
       "version": "1.0.10",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__data-structures/1.0.10.tgz",
       "integrity": "sha512-NUlT54X5Ob7AUvl0nVdeOcXPdrKbg1TnaZnh72rhNIvaWprTT1jriFL+UilSAFtImo2OMEVajuudBFWoGre1pg==",
+      "inBundle": true,
       "dependencies": {
         "@jsr/std__assert": "^1.0.17"
       }
@@ -543,12 +561,14 @@
     "node_modules/@jsr/std__fmt": {
       "version": "1.0.9",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__fmt/1.0.9.tgz",
-      "integrity": "sha512-YFJJMozmORj2K91c5J9opWeh0VUwrd+Mwb7Pr0FkVCAKVLu2UhT4LyvJqWiyUT+eF+MdfqQ9F7RtQj4bXn9Smw=="
+      "integrity": "sha512-YFJJMozmORj2K91c5J9opWeh0VUwrd+Mwb7Pr0FkVCAKVLu2UhT4LyvJqWiyUT+eF+MdfqQ9F7RtQj4bXn9Smw==",
+      "inBundle": true
     },
     "node_modules/@jsr/std__fs": {
       "version": "1.0.23",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__fs/1.0.23.tgz",
       "integrity": "sha512-e8jspB3M44E5YhWiLCTqibBBTwVmxQaHN06WvFa/elAKm5E/LfAe8Hj5XGNC8P7a0MIPASlNJsnF1bgO/g+aqg==",
+      "inBundle": true,
       "dependencies": {
         "@jsr/std__internal": "^1.0.12",
         "@jsr/std__path": "^1.1.4"
@@ -557,12 +577,14 @@
     "node_modules/@jsr/std__internal": {
       "version": "1.0.12",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__internal/1.0.12.tgz",
-      "integrity": "sha512-6xReMW9p+paJgqoFRpOE2nogJFvzPfaLHLIlyADYjKMUcwDyjKZxryIbgcU+gxiTygn8yCjld1HoI0ET4/iZeA=="
+      "integrity": "sha512-6xReMW9p+paJgqoFRpOE2nogJFvzPfaLHLIlyADYjKMUcwDyjKZxryIbgcU+gxiTygn8yCjld1HoI0ET4/iZeA==",
+      "inBundle": true
     },
     "node_modules/@jsr/std__path": {
       "version": "1.1.4",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__path/1.1.4.tgz",
       "integrity": "sha512-SK4u9H6NVTfolhPdlvdYXfNFefy1W04AEHWJydryYbk+xqzNiVmr5o7TLJLJFqwHXuwMRhwrn+mcYeUfS0YFaA==",
+      "inBundle": true,
       "dependencies": {
         "@jsr/std__internal": "^1.0.12"
       }
@@ -571,6 +593,7 @@
       "version": "1.0.11",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__toml/1.0.11.tgz",
       "integrity": "sha512-+LZAizoPAPwMDmRZr86/xPrbO8E0Oq0BJ70mr1fNMobJ/6X6v15Jk16ZClFGukWgzBMd8ggiMWnzp24+N3VNZg==",
+      "inBundle": true,
       "dependencies": {
         "@jsr/std__collections": "^1.1.3"
       }
@@ -578,7 +601,8 @@
     "node_modules/@jsr/std__yaml": {
       "version": "1.0.12",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__yaml/1.0.12.tgz",
-      "integrity": "sha512-pz/BisWZWH16JvLJBwrNwUwfIsRnf9qniMrmI6Z3vIAcVRVFcA5+i4o6z6QqsMKqFzjlB66WZE+jSyujT/RvRg=="
+      "integrity": "sha512-pz/BisWZWH16JvLJBwrNwUwfIsRnf9qniMrmI6Z3vIAcVRVFcA5+i4o6z6QqsMKqFzjlB66WZE+jSyujT/RvRg==",
+      "inBundle": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -970,6 +994,7 @@
       "version": "1.0.19",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__assert/1.0.19.tgz",
       "integrity": "sha512-pEj6RPkGbqlgRmyKwATp4cUs6+ijxtdrv3bq8v1d2I2CEcMEyPaO8cVKro61wGRDH4cNg8Zx6haztvK/9m7gkA==",
+      "inBundle": true,
       "dependencies": {
         "@jsr/std__internal": "^1.0.12"
       }
@@ -978,13 +1003,15 @@
       "name": "@jsr/std__async",
       "version": "1.2.0",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__async/1.2.0.tgz",
-      "integrity": "sha512-/vlTKrVwDp9iBCi1BUlz4ghyvHNkzGHdvhdHTdPKGJoklBcwnRjm4yC0n+oB97LtRRFpruWmBobABZHD/t/SkQ=="
+      "integrity": "sha512-/vlTKrVwDp9iBCi1BUlz4ghyvHNkzGHdvhdHTdPKGJoklBcwnRjm4yC0n+oB97LtRRFpruWmBobABZHD/t/SkQ==",
+      "inBundle": true
     },
     "node_modules/@std/cli": {
       "name": "@jsr/std__cli",
       "version": "1.0.28",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__cli/1.0.28.tgz",
       "integrity": "sha512-PCLSj0MeBw3nAm0qiYACCqz0qWLEmWNbKUbcf7MX9PYZyDbhKiv7FI34vuHFrNGJ8QZeQ5mSiHuSkG210o4L6g==",
+      "inBundle": true,
       "dependencies": {
         "@jsr/std__fmt": "^1.0.9",
         "@jsr/std__internal": "^1.0.12"
@@ -994,19 +1021,22 @@
       "name": "@jsr/std__dotenv",
       "version": "0.225.6",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__dotenv/0.225.6.tgz",
-      "integrity": "sha512-rqh5RrHccbyzmP4v1/vqUyYy4dqopjTRgW8bJqk2ZXTKBbvpmMjPxJ+xy+YAk6XnEvtPCPAgqbFhHWcomjnX+w=="
+      "integrity": "sha512-rqh5RrHccbyzmP4v1/vqUyYy4dqopjTRgW8bJqk2ZXTKBbvpmMjPxJ+xy+YAk6XnEvtPCPAgqbFhHWcomjnX+w==",
+      "inBundle": true
     },
     "node_modules/@std/fmt": {
       "name": "@jsr/std__fmt",
       "version": "1.0.9",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__fmt/1.0.9.tgz",
-      "integrity": "sha512-YFJJMozmORj2K91c5J9opWeh0VUwrd+Mwb7Pr0FkVCAKVLu2UhT4LyvJqWiyUT+eF+MdfqQ9F7RtQj4bXn9Smw=="
+      "integrity": "sha512-YFJJMozmORj2K91c5J9opWeh0VUwrd+Mwb7Pr0FkVCAKVLu2UhT4LyvJqWiyUT+eF+MdfqQ9F7RtQj4bXn9Smw==",
+      "inBundle": true
     },
     "node_modules/@std/front-matter": {
       "name": "@jsr/std__front-matter",
       "version": "1.0.9",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__front-matter/1.0.9.tgz",
       "integrity": "sha512-CSz8B8ABdHk9O1sbeIhR+hwIfrIImhTzCMxPWnFmwtuoIHoOAqHQJKmKFl0r2MYD5TZlN+t+Z+0wlp0dfU0TaA==",
+      "inBundle": true,
       "dependencies": {
         "@jsr/std__toml": "^1.0.3",
         "@jsr/std__yaml": "^1.0.5"
@@ -1017,6 +1047,7 @@
       "version": "1.0.23",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__fs/1.0.23.tgz",
       "integrity": "sha512-e8jspB3M44E5YhWiLCTqibBBTwVmxQaHN06WvFa/elAKm5E/LfAe8Hj5XGNC8P7a0MIPASlNJsnF1bgO/g+aqg==",
+      "inBundle": true,
       "dependencies": {
         "@jsr/std__internal": "^1.0.12",
         "@jsr/std__path": "^1.1.4"
@@ -1026,13 +1057,15 @@
       "name": "@jsr/std__media-types",
       "version": "1.1.0",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__media-types/1.1.0.tgz",
-      "integrity": "sha512-dHvaxHL7ENWnltgL653uo3KnKFse3ZbopZop2gqsT7yrscx7irZEClu5Cba7gMPPRk4Lg1FbriNcaBViM2RSBw=="
+      "integrity": "sha512-dHvaxHL7ENWnltgL653uo3KnKFse3ZbopZop2gqsT7yrscx7irZEClu5Cba7gMPPRk4Lg1FbriNcaBViM2RSBw==",
+      "inBundle": true
     },
     "node_modules/@std/path": {
       "name": "@jsr/std__path",
       "version": "1.1.4",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__path/1.1.4.tgz",
       "integrity": "sha512-SK4u9H6NVTfolhPdlvdYXfNFefy1W04AEHWJydryYbk+xqzNiVmr5o7TLJLJFqwHXuwMRhwrn+mcYeUfS0YFaA==",
+      "inBundle": true,
       "dependencies": {
         "@jsr/std__internal": "^1.0.12"
       }
@@ -1042,6 +1075,7 @@
       "version": "1.0.17",
       "resolved": "https://npm.jsr.io/~/11/@jsr/std__testing/1.0.17.tgz",
       "integrity": "sha512-szX1c5vuBvEo4LKLhaPCPZ4X7LO4nqGYwEhKnWwuPbqG0wnCRUY0IVZ4X191EZNgu+4qciYeQap1O4QCooulow==",
+      "inBundle": true,
       "dependencies": {
         "@jsr/std__assert": "^1.0.17",
         "@jsr/std__async": "^1.1.0",
@@ -1195,7 +1229,8 @@
       "name": "@jsr/wilcosp__ms-relative",
       "version": "0.1.4",
       "resolved": "https://npm.jsr.io/~/11/@jsr/wilcosp__ms-relative/0.1.4.tgz",
-      "integrity": "sha512-BaPHe7kPlDzY6Px/N1d86BkwVNqps6Qv3glUTTkzdQNMfS/pyEhQ+XYB8H7ESE0FYDZWMEsAst0pcBmXd8YkiA=="
+      "integrity": "sha512-BaPHe7kPlDzY6Px/N1d86BkwVNqps6Qv3glUTTkzdQNMfS/pyEhQ+XYB8H7ESE0FYDZWMEsAst0pcBmXd8YkiA==",
+      "inBundle": true
     },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garndev/tepi",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "bin": {
     "tepi": "bin/tepi.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garndev/tepi",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "MIT",
   "type": "module",
   "bin": {
@@ -43,6 +43,19 @@
     "react": "^19.2.4",
     "zustand": "^4.0.0"
   },
+  "bundleDependencies": [
+    "@std/assert",
+    "@std/async",
+    "@std/cli",
+    "@std/dotenv",
+    "@std/fmt",
+    "@std/front-matter",
+    "@std/fs",
+    "@std/media-types",
+    "@std/path",
+    "@std/testing",
+    "@wilcosp/ms-relative"
+  ],
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garndev/tepi",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@garndev/tepi",
   "version": "2.0.1",
+  "license": "MIT",
   "type": "module",
   "bin": {
     "tepi": "bin/tepi.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garndev/tepi",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garndev/tepi",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@garn/tepi",
+  "name": "@garndev/tepi",
   "version": "2.0.0",
   "type": "module",
   "bin": {
-    "tepi": "./bin/tepi.mjs"
+    "tepi": "bin/tepi.mjs"
   },
   "exports": {
     ".": "./src/cli.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garn/tepi",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "type": "module",
   "bin": {
     "tepi": "./bin/tepi.mjs"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,9 @@ process.on("SIGINT", () => {
   exit(143);
 });
 
-const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+const isMain = import.meta.url.startsWith("file:")
+  ? process.argv[1] === fileURLToPath(import.meta.url)
+  : (import.meta as { main?: boolean }).main ?? false;
 if (isMain) {
   await cli();
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,9 +18,8 @@ import chokidar from "chokidar";
 
 const execFile = promisify(_execFile);
 
-const mustExit = !process.env.TEPI_NOT_EXIT;
 function exit(code: number) {
-  mustExit && process.exit(code);
+  !process.env.TEPI_NOT_EXIT && process.exit(code);
 }
 
 let _activeStore: ReturnType<typeof createStore> | undefined;

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -45,18 +45,31 @@ Test your HTTP APIs with standard http syntax
 
 ## Install:
 
+### From npm
 
 ```bash
-deno install --global --reload  --allow-read --allow-env --allow-net --allow-run -f -n tepi https://tepi.deno.dev/src/cli.ts
+npm install -g @garn/tepi
 ```
 
-Or run remotely with:
+### From JSR
 
 ```bash
-deno run --allow-read --allow-env --allow-net --allow-run https://tepi.deno.dev/src/cli.ts
+npx jsr add -g @garn/tepi
 ```
 
-### Permissions:
+### From deno.land/x
+
+```bash
+deno install --global -A -n tepi https://deno.land/x/tepi/mod.ts
+```
+
+### Run without installing (npx)
+
+```bash
+npx @garn/tepi [OPTIONS] [FILES|GLOBS...]
+```
+
+### Permissions (Deno only):
 
 * `--allow-read`  Needed to read files from the file system.
 * `--allow-net`   Needed to make HTTP requests.

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "tepi",
   "displayName": "tepi",
   "description": "support for .http files handled by tepi",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "publisher": "jupegarnica",
   "scripts": {
     "build": "vsce package",


### PR DESCRIPTION
- Changed imports from "jsr:@std/*" to "@std/*" for consistency and to align with the latest module structure.
- Updated the highlight function to use 'node:util' for inspecting JSON instead of Deno's inspect.
- Modified the runner to use 'node:path' for path operations instead of Deno's path module.
- Adjusted test files to use Vitest instead of Deno's test runner, updating all test cases accordingly.
- Added TypeScript configuration (tsconfig.json) for better type checking and module resolution.
- Introduced Vitest configuration (vitest.config.ts) to streamline testing setup.