### PR TITLE
feat: replace custom Scroll component with ink-scrollbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       ],
       "license": "MIT",
       "dependencies": {
+        "@byteland/ink-scroll-bar": "^1.0.0",
         "@std/assert": "npm:@jsr/std__assert@^1.0.19",
         "@std/async": "npm:@jsr/std__async@^1.2.0",
         "@std/cli": "npm:@jsr/std__cli@^1.0.28",
@@ -68,6 +69,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@byteland/ink-scroll-bar": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@byteland/ink-scroll-bar/-/ink-scroll-bar-1.0.0.tgz",
+      "integrity": "sha512-5wfUK9H6iQI3v66uk7nQ3mJIahooA2oYpVKc5PtXMb68+z8EbWFT15wxVSJ9/x8an8oGgeGvdJcLCKdv9bjVdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ink": ">=6",
+        "react": ">=19"
       }
     },
     "node_modules/@colors/colors": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "install:local": "npm link"
   },
   "dependencies": {
+    "@byteland/ink-scroll-bar": "^1.0.0",
     "@std/assert": "npm:@jsr/std__assert@^1.0.19",
     "@std/async": "npm:@jsr/std__async@^1.2.0",
     "@std/cli": "npm:@jsr/std__cli@^1.0.28",

--- a/src/ui/shared/Scroll/Scroll.tsx
+++ b/src/ui/shared/Scroll/Scroll.tsx
@@ -1,19 +1,18 @@
 import React from "react";
-import { Box, Text, useStdout } from "ink";
+import { Box, Text } from "ink";
 import { ScrollBar } from "@byteland/ink-scroll-bar";
 import type { ScrollProps } from "./Scroll.types.ts";
 import { useScroll } from "./hooks/useScroll.hook.ts";
 
 export function Scroll({ height, children }: ScrollProps) {
-  const { stdout } = useStdout();
-  const columns = stdout?.columns ?? 80;
-  const { visibleLines, aboveCount, totalLines } = useScroll({ children, height, columns });
+  const safeHeight = Math.floor(height);
+  const { visibleLines, aboveCount, totalLines } = useScroll({ children, height: safeHeight });
 
   if (visibleLines.length === 0) {
     return null;
   }
 
-  const needsScrollbar = totalLines > height;
+  const needsScrollbar = totalLines > safeHeight;
 
   return (
     <Box flexDirection="row">
@@ -23,7 +22,7 @@ export function Scroll({ height, children }: ScrollProps) {
           placement="inset"
           style="line"
           contentHeight={totalLines}
-          viewportHeight={height}
+          viewportHeight={safeHeight}
           scrollOffset={aboveCount}
         />
       )}

--- a/src/ui/shared/Scroll/Scroll.tsx
+++ b/src/ui/shared/Scroll/Scroll.tsx
@@ -1,16 +1,32 @@
 import React from "react";
-import { Text, useStdout } from "ink";
+import { Box, Text, useStdout } from "ink";
+import { ScrollBar } from "@byteland/ink-scroll-bar";
 import type { ScrollProps } from "./Scroll.types.ts";
 import { useScroll } from "./hooks/useScroll.hook.ts";
 
 export function Scroll({ height, children }: ScrollProps) {
   const { stdout } = useStdout();
   const columns = stdout?.columns ?? 80;
-  const { displayLines } = useScroll({ children, height, columns });
+  const { visibleLines, aboveCount, totalLines } = useScroll({ children, height, columns });
 
-  if (displayLines.length === 0) {
+  if (visibleLines.length === 0) {
     return null;
   }
 
-  return <Text>{displayLines.join("\n")}</Text>;
+  const needsScrollbar = totalLines > height;
+
+  return (
+    <Box flexDirection="row">
+      <Text>{visibleLines.join("\n")}</Text>
+      {needsScrollbar && (
+        <ScrollBar
+          placement="inset"
+          style="line"
+          contentHeight={totalLines}
+          viewportHeight={height}
+          scrollOffset={aboveCount}
+        />
+      )}
+    </Box>
+  );
 }

--- a/src/ui/shared/Scroll/Scroll.types.ts
+++ b/src/ui/shared/Scroll/Scroll.types.ts
@@ -10,7 +10,6 @@ export type ScrollProps = {
 export type UseScrollArgs = {
   children: ReactNode;
   height: number;
-  columns: number;
 };
 
 export type UseScrollResult = {

--- a/src/ui/shared/Scroll/Scroll.types.ts
+++ b/src/ui/shared/Scroll/Scroll.types.ts
@@ -14,7 +14,7 @@ export type UseScrollArgs = {
 };
 
 export type UseScrollResult = {
+  visibleLines: string[];
   aboveCount: number;
-  belowCount: number;
-  displayLines: string[];
+  totalLines: number;
 };

--- a/src/ui/shared/Scroll/hooks/useScroll.hook.ts
+++ b/src/ui/shared/Scroll/hooks/useScroll.hook.ts
@@ -168,7 +168,7 @@ function computeDisplayLines(lines: string[], anchorLine: number, height: number
   };
 }
 
-export function useScroll({ children, height, columns }: UseScrollArgs): UseScrollResult {
+export function useScroll({ children, height }: UseScrollArgs): UseScrollResult {
   return useMemo(() => {
     const renderedOutput = renderNodeToString(children);
     const rawLines = normalizeLines(renderedOutput);
@@ -176,5 +176,5 @@ export function useScroll({ children, height, columns }: UseScrollArgs): UseScro
     const sanitizedLines = sanitizeLines(rawLines);
 
     return computeDisplayLines(sanitizedLines, anchorLine, height);
-  }, [children, columns, height]);
+  }, [children, height]);
 }

--- a/src/ui/shared/Scroll/hooks/useScroll.hook.ts
+++ b/src/ui/shared/Scroll/hooks/useScroll.hook.ts
@@ -147,91 +147,24 @@ function centerViewport(anchorLine: number, visibleLineCount: number, totalLineC
   );
 }
 
-function formatCombinedMarker(aboveCount: number, belowCount: number): string {
-  if (aboveCount > 0 && belowCount > 0) {
-    return fmt.dim(`  ↑ ${aboveCount} more | ↓ ${belowCount} more`);
-  }
-
-  if (aboveCount > 0) {
-    return fmt.dim(`  ↑ ${aboveCount} more`);
-  }
-
-  return fmt.dim(`  ↓ ${belowCount} more`);
-}
-
 function computeDisplayLines(lines: string[], anchorLine: number, height: number): UseScrollResult {
   const safeHeight = Math.max(0, Math.floor(height));
 
   if (safeHeight === 0 || lines.length === 0) {
-    return { aboveCount: 0, belowCount: 0, displayLines: [] };
-  }
-
-  if (safeHeight === 1) {
-    const selectedLine = lines[Math.min(anchorLine, lines.length - 1)] ?? "";
-    const aboveCount = Math.min(anchorLine, Math.max(0, lines.length - 1));
-    const belowCount = Math.max(0, lines.length - anchorLine - 1);
-
-    if (aboveCount > 0 || belowCount > 0) {
-      return {
-        aboveCount,
-        belowCount,
-        displayLines: [formatCombinedMarker(aboveCount, belowCount)],
-      };
-    }
-
-    return { aboveCount: 0, belowCount: 0, displayLines: [selectedLine] };
+    return { visibleLines: [], aboveCount: 0, totalLines: 0 };
   }
 
   if (lines.length <= safeHeight) {
-    return { aboveCount: 0, belowCount: 0, displayLines: lines };
+    return { visibleLines: lines, aboveCount: 0, totalLines: lines.length };
   }
 
-  let markerRows = safeHeight >= 3 ? 2 : 1;
-  let aboveCount = 0;
-  let belowCount = 0;
-  let visibleLines: string[] = [];
-
-  for (let attempt = 0; attempt < 3; attempt++) {
-    const visibleLineCount = Math.max(1, safeHeight - markerRows);
-    const viewportStart = centerViewport(anchorLine, visibleLineCount, lines.length);
-    const viewportEnd = viewportStart + visibleLineCount;
-
-    aboveCount = viewportStart;
-    belowCount = Math.max(0, lines.length - viewportEnd);
-    visibleLines = lines.slice(viewportStart, viewportEnd);
-
-    const nextMarkerRows = safeHeight >= 3
-      ? Number(aboveCount > 0) + Number(belowCount > 0)
-      : Number(aboveCount > 0 || belowCount > 0);
-
-    if (nextMarkerRows === markerRows) break;
-    markerRows = nextMarkerRows;
-  }
-
-  if (safeHeight === 2 && aboveCount > 0 && belowCount > 0) {
-    return {
-      aboveCount,
-      belowCount,
-      displayLines: [formatCombinedMarker(aboveCount, belowCount), ...visibleLines.slice(0, 1)],
-    };
-  }
-
-  const displayLines: string[] = [];
-
-  if (aboveCount > 0) {
-    displayLines.push(fmt.dim(`  ↑ ${aboveCount} more`));
-  }
-
-  displayLines.push(...visibleLines);
-
-  if (belowCount > 0) {
-    displayLines.push(fmt.dim(`  ↓ ${belowCount} more`));
-  }
+  const viewportStart = centerViewport(anchorLine, safeHeight, lines.length);
+  const visibleLines = lines.slice(viewportStart, viewportStart + safeHeight);
 
   return {
-    aboveCount,
-    belowCount,
-    displayLines: displayLines.slice(0, safeHeight),
+    visibleLines,
+    aboveCount: viewportStart,
+    totalLines: lines.length,
   };
 }
 

--- a/test/scroll.test.ts
+++ b/test/scroll.test.ts
@@ -29,7 +29,7 @@ async function renderRawFrame(node: React.ReactElement) {
   return frame;
 }
 
-test("[scroll] renders arbitrary ReactNode content without markers when it fits", async () => {
+test("[scroll] renders arbitrary ReactNode content without scrollbar when it fits", async () => {
   const frame = await renderFrame(
     React.createElement(
       Scroll,
@@ -93,7 +93,7 @@ test("[scroll] preserves Ink Text colors while serializing component trees", asy
   }
 });
 
-test("[scroll] centers the anchor line and shows both overflow markers", async () => {
+test("[scroll] centers the anchor line and shows a scrollbar when content overflows", async () => {
   const lines = [
     "one",
     "two",
@@ -109,10 +109,13 @@ test("[scroll] centers the anchor line and shows both overflow markers", async (
     ),
   );
 
-  assertEquals(frame, "  ↑ 2 more\n· three\n  ↓ 2 more");
+  assertStringIncludes(frame, "· three");
+  assert(!frame.includes("↑"));
+  assert(!frame.includes("↓"));
+  assert(!frame.includes(SCROLL_ANCHOR_SENTINEL));
 });
 
-test("[scroll] collapses both counts into one marker line when height is two", async () => {
+test("[scroll] shows all lines when height equals content height", async () => {
   const lines = [
     "one",
     "two",
@@ -124,11 +127,14 @@ test("[scroll] collapses both counts into one marker line when height is two", a
   const frame = await renderFrame(
     React.createElement(
       Scroll,
-      { height: 2, children: React.createElement(Text, null, lines) },
+      { height: 5, children: React.createElement(Text, null, lines) },
     ),
   );
 
-  assertEquals(frame, "  ↑ 2 more | ↓ 2 more\n· three");
+  assertStringIncludes(frame, "one");
+  assertStringIncludes(frame, "· three");
+  assertStringIncludes(frame, "five");
+  assert(!frame.includes(SCROLL_ANCHOR_SENTINEL));
 });
 
 function createInteractiveProps(fileCount: number): InteractiveProps {
@@ -167,13 +173,13 @@ function createInteractiveProps(fileCount: number): InteractiveProps {
   };
 }
 
-test("[interactive] done phase uses Scroll to show overflow counts", async () => {
+test("[interactive] done phase uses Scroll to show overflow content with scrollbar", async () => {
   const frame = await renderFrame(
     React.createElement(DisplayInteractive, createInteractiveProps(20)),
   );
 
-  assertStringIncludes(frame, "  ↓ 5 more");
   assertStringIncludes(frame, "http/file-1.http");
   assertStringIncludes(frame, "↑↓ navigate");
   assert(!frame.includes("__TEPI_SCROLL_ANCHOR__"));
+  assert(!frame.includes("↓ 5 more"));
 });

--- a/test/scroll.test.ts
+++ b/test/scroll.test.ts
@@ -113,6 +113,8 @@ test("[scroll] centers the anchor line and shows a scrollbar when content overfl
   assert(!frame.includes("↑"));
   assert(!frame.includes("↓"));
   assert(!frame.includes(SCROLL_ANCHOR_SENTINEL));
+  // scrollbar thumb character (│ U+2502) must be present when content overflows
+  assert(frame.includes("\u2502"), "scrollbar should be visible when content overflows");
 });
 
 test("[scroll] shows all lines when height equals content height", async () => {
@@ -135,6 +137,8 @@ test("[scroll] shows all lines when height equals content height", async () => {
   assertStringIncludes(frame, "· three");
   assertStringIncludes(frame, "five");
   assert(!frame.includes(SCROLL_ANCHOR_SENTINEL));
+  // no scrollbar when content fits exactly
+  assert(!frame.includes("\u2502"), "scrollbar should not appear when content fits");
 });
 
 function createInteractiveProps(fileCount: number): InteractiveProps {
@@ -182,4 +186,6 @@ test("[interactive] done phase uses Scroll to show overflow content with scrollb
   assertStringIncludes(frame, "↑↓ navigate");
   assert(!frame.includes("__TEPI_SCROLL_ANCHOR__"));
   assert(!frame.includes("↓ 5 more"));
+  // scrollbar thumb character (│ U+2502) must be visible when content overflows
+  assert(frame.includes("\u2502"), "scrollbar should be visible when the file list overflows");
 });


### PR DESCRIPTION
Replace the custom scroll implementation that showed "↑ N more" / "↓ N more"
text markers with @byteland/ink-scroll-bar's ScrollBar component for a proper
visual scrollbar indicator.

- Install @byteland/ink-scroll-bar
- Simplify useScroll hook: remove marker-row logic, return visibleLines/aboveCount/totalLines
- Update Scroll.tsx to render content + ScrollBar (inset/line style, auto-hidden when fits)
- Update scroll tests to reflect new behavior (no text markers, scrollbar shown on overflow)

https://claude.ai/code/session_01ERx1KkaEwutGb1EZvXwBxs